### PR TITLE
Fix memory leak and gcc warning.

### DIFF
--- a/game.c
+++ b/game.c
@@ -124,4 +124,5 @@ cleanup:
     nfree(ss);
     nfree(g);
     nfree(b);
+    free_shape();
 }

--- a/move.c
+++ b/move.c
@@ -160,12 +160,14 @@ move_t *best_move(grid_t *g, block_t *b, shape_stream_t *ss, float *w)
         grids = ncalloc(depth, sizeof(*grids), g);
         blocks = ncalloc(depth, sizeof(*blocks), b);
         best_moves = nrealloc(best_moves, depth * sizeof(*best_moves));
+        nalloc_set_parent(best_moves, grids);
         for (int i = n_grids; i < ss->max_len; i++) {
             grids[i] = grid_new(g->height, g->width);
             nalloc_set_parent(grids[i], grids);
             blocks[i] = block_new();
             nalloc_set_parent(blocks[i], blocks);
             best_moves[i] = nalloc(sizeof(*best_moves[i]), best_moves);
+            nalloc_set_parent(best_moves[i], best_moves);
         }
         n_grids = ss->max_len;
     }

--- a/shape.c
+++ b/shape.c
@@ -265,3 +265,8 @@ shape_t *shape_stream_pop(shape_stream_t *stream)
 {
     return shape_stream_access(stream, -1);
 }
+
+void free_shape(void)
+{
+    nfree(shapes);
+}

--- a/tetris.h
+++ b/tetris.h
@@ -101,3 +101,5 @@ input_t tui_scankey(void);
 float *default_weights();
 move_t *best_move(grid_t *g, block_t *b, shape_stream_t *ss, float *w);
 void auto_play(float *w);
+
+void free_shape(void);

--- a/tui.c
+++ b/tui.c
@@ -38,7 +38,7 @@ void tui_prompt(const grid_t *g, const char *msg)
     if (!msg)
         return;
 
-    mvprintw(g->height / 2, 2, msg);
+    mvaddstr(g->height / 2, 2, msg);
     refresh();
 }
 


### PR DESCRIPTION
Connect 'best_moves' and 'grids'. When 'grids' is freed, so does 'best_moves'.
Because of 'shapes' is static variable, add free_shape() to free 'shapes'.

GCC warn mvprintw() [-Wformat-security]. Change to mvaddstr() to suppress warning.